### PR TITLE
Provide more info and add time request

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,18 @@ function start() {
     });
   });
 
+  app.get('/time', function(req, res){
+    broker.publish('time.get', {}, function onTime(err, retTime) {
+      res.send(retTime);
+    });
+  });
+
 
   app.listen(8080);
 
   function listen() {
     broker.create('info.get');
+    broker.create('time.get');
   }
 
   function exit(reason) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function start() {
 
   app.get('/info', function(req, res){
     broker.publish('info.get', {}, function onInfo(err, retInfo) {
-      res.send({info: retInfo});
+      res.send(retInfo);
     });
   });
 

--- a/services/info.js
+++ b/services/info.js
@@ -22,7 +22,7 @@ function start() {
     logger.log({ type: 'info', message: 'serving info' });
 
     broker.handle('info.get', function getInfo(message, reply) {
-      logger.log({ type: 'info', message: 'info served from this process.' });
+      logger.log({ type: 'info', message: 'info served from process: ' + process.pid });
       reply({
         info: "Here is your info",
         served_from_process: process.pid

--- a/services/info.js
+++ b/services/info.js
@@ -8,7 +8,7 @@ var RABBIT_URL = process.env.CLOUDAMQP_URL || 'amqp://localhost';
 throng(start, { workers: cpus, lifetime: Infinity });
 
 function start() {
-  logger.log({ type: 'info', message: 'starting info service' });
+  logger.log({ type: 'info', message: 'starting info service on process ' + process.pid });
 
   var broker = jackrabbit(RABBIT_URL, 1);
   broker.once('connected', create);
@@ -23,7 +23,10 @@ function start() {
 
     broker.handle('info.get', function getInfo(message, reply) {
       logger.log({ type: 'info', message: 'info served from this process.' });
-      reply("Here is your info");
+      reply({
+        info: "Here is your info",
+        served_from_process: process.pid
+      });
     });
   }
 

--- a/services/time.js
+++ b/services/time.js
@@ -1,0 +1,39 @@
+var jackrabbit = require('jackrabbit');
+var logger = require('logfmt');
+var throng = require('throng');
+var cpus = require('os').cpus().length;
+
+var RABBIT_URL = process.env.CLOUDAMQP_URL || 'amqp://localhost';
+
+throng(start, { workers: cpus, lifetime: Infinity });
+
+function start() {
+  logger.log({ type: 'info', message: 'starting time service on process ' + process.pid });
+
+  var broker = jackrabbit(RABBIT_URL, 1);
+  broker.once('connected', create);
+  process.once('uncaughtException', onError);
+
+  function create() {
+    broker.create('time.get', serve);
+  }
+
+  function serve() {
+    logger.log({ type: 'time', message: 'serving time' });
+
+    broker.handle('time.get', function gettime(message, reply) {
+      logger.log({ type: 'time', message: 'time served from process: ' + process.pid });
+      var currentTime = 'The time is: ' + (new Date()).toTimeString();
+      reply({
+        time: currentTime,
+        served_from_process: process.pid
+      });
+    });
+  }
+
+  function onError(err) {
+    logger.log({ type: 'error', service: 'time', error: err, stack: err.stack || 'No stacktrace' }, process.stderr);
+    logger.log({ type: 'info', message: 'killing time service' });
+    process.exit();
+  }
+}


### PR DESCRIPTION
Given that a service will start on #cpu processes I thought it would make sense to log the process doing the work and return that id to the caller to show that it's being served from different processes each time.
